### PR TITLE
fix: 修复重复的路由定义

### DIFF
--- a/src/server/server.py
+++ b/src/server/server.py
@@ -148,16 +148,6 @@ async def api_update_task(req: TaskUpdate):
         raise HTTPException(status_code=500, detail="更新任务失败")
 
 
-@app.post("/api/tasks/update", response_model=dict, dependencies=[Depends(verify_token)])
-async def api_update_task(req: TaskUpdate):
-    try:
-        new_task = await update_task(req)
-        await update_scheduled_task(new_task)
-        return success_response("任务更新成功", new_task)
-    except Exception:
-        raise HTTPException(status_code=500, detail="更新任务失败")
-
-
 @app.delete("/api/tasks/delete/{task_id}", response_model=dict, dependencies=[Depends(verify_token)])
 async def api_remove_task(task_id: int):
     try:


### PR DESCRIPTION
## 问题描述
在 `src/server/server.py` 文件中发现了重复的路由定义，具体是 `/api/tasks/update` 路由被定义了两次，这可能导致路由冲突和不可预期的行为。

## 修复内容
- 删除了重复的 `/api/tasks/update` POST 路由定义
- 保留了包含完整调度器逻辑的版本，该版本能够正确处理：
  - 任务启用/禁用状态的切换
  - 调度器中任务的添加/移除
  - 调度器中任务的更新

## 技术细节
- 第一个版本的 `api_update_task` 函数包含了完整的调度器管理逻辑
- 第二个重复的版本是简化版本，缺少调度器状态管理
- 修复后保留了功能更完整的版本

## 验证
- ✅ 代码语法检查通过
- ✅ 没有发现其他重复的函数定义
- ✅ 模块可以正常编译

## 影响范围
- 仅影响服务器路由定义
- 不影响现有功能
- 修复了潜在的路由冲突问题

Co-authored-by: openhands <openhands@all-hands.dev>

@just-ads can click here to [continue refining the PR](https://app.all-hands.dev/conversations/b99e922b750b430090f855da6cb6ec27)